### PR TITLE
Small bug fix

### DIFF
--- a/Assets/Scripts/Player Scripts/Interactor.cs
+++ b/Assets/Scripts/Player Scripts/Interactor.cs
@@ -47,8 +47,12 @@ public class Interactor : MonoBehaviour
                 onInteract.Invoke();
             }
         } else {
-            onNoInteraction = prevHit.GetComponent<Interactable>().onNoInteraction;
-            onNoInteraction.Invoke();
+            if (prevHit != null)
+            {
+                onNoInteraction = prevHit.GetComponent<Interactable>().onNoInteraction;
+                onNoInteraction.Invoke();
+            }
+            
         }
     }
 }


### PR DESCRIPTION
Small bug fix for unassigned puzzle object. Also made a check for the previously hit item so it no longer displays a bunch of NullPointException errors (these errors were not gamebreaking, fix is just visual in terms of the console basically).